### PR TITLE
feat: add frontend setup instructions and text translation component

### DIFF
--- a/README-ja.md
+++ b/README-ja.md
@@ -45,6 +45,8 @@ type TranslateResultAllItemDetectedLanguage struct {
 Server is running on port 8080
 ```
 
+- [フロントエンド起動手順書](./frontend/README-ja.md)
+
 ## APIの終了方法
 
 サーバーを終了するには、ターミナルで `Ctrl+C` を押してください。グレースフルシャットダウンが実行されます。

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ When the server starts successfully, you will see a message like:
 Server is running on port 8080
 ```
 
+- [How to setup frontend App](./frontend/README.md)
+
 ## Stopping the API
 
 To stop the server, press `Ctrl+C` in the terminal. A graceful shutdown will be performed.

--- a/frontend/README-ja.md
+++ b/frontend/README-ja.md
@@ -1,66 +1,66 @@
-# Real-time Translation Application Frontend
+# リアルタイム翻訳アプリケーション フロントエンド
 
-This is the frontend of a web application that performs real-time voice translation. It is built using React, TypeScript, and Vite.
+音声のリアルタイム翻訳を行うWebアプリケーションのフロントエンドです。React、TypeScript、Viteを使用して構築されています。
 
-## Features
+## 機能
 
-- Text translation
-- Real-time voice translation
-- Modern UI based on Material-UI
+- テキスト翻訳
+- リアルタイム音声翻訳
+- Material-UIベースのモダンなUI
 
-## Requirements
+## 必要条件
 
-- Node.js (v18 or higher)
-- npm or yarn
+- Node.js (v18以上)
+- npm または yarn
 
-## Setup Instructions
+## セットアップ手順
 
-1. Install dependencies:
+1. 依存パッケージのインストール:
 ```bash
 npm install
-# or
+# または
 yarn
 ```
 
-2. Start development server:
+2. 開発サーバーの起動:
 ```bash
 npm run dev
-# or
+# または
 yarn dev
 ```
 
-The application will start at http://localhost:5173 by default.
+アプリケーションは デフォルトで http://localhost:5173 で起動します。
 
-## Available Scripts
+## 利用可能なスクリプト
 
-- `npm run dev`: Start development server
-- `npm run build`: Build application for production
-- `npm run preview`: Preview built application
-- `npm run lint`: Validate code with ESLint
+- `npm run dev`: 開発サーバーを起動します
+- `npm run build`: プロダクション用にアプリケーションをビルドします
+- `npm run preview`: ビルドしたアプリケーションをプレビューします
+- `npm run lint`: ESLintでコードを検証します
 
-## Development
+## 開発
 
-This application uses the following key technologies:
+このアプリケーションは以下の主要な技術を使用しています：
 
 - React v19
 - TypeScript
 - Material-UI v6
 - Vite v6
-- Axios (API client)
+- Axios (APIクライアント)
 
-For backend API communication, it uses `http://localhost:8080` by default.
+バックエンドAPIとの通信には、デフォルトで `http://localhost:8080` を使用します。
 
-## Production Deployment
+## 本番環境へのデプロイ
 
-Generate production files by running the build:
+ビルドを実行してプロダクション用のファイルを生成：
 
 ```bash
 npm run build
-# or
+# または
 yarn build
 ```
 
-Built files will be generated in the `dist` directory.
+ビルドされたファイルは `dist` ディレクトリに生成されます。
 
 ## Expanding the ESLint configuration
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import './App.css'
 import { CssBaseline, ThemeProvider, createTheme } from '@mui/material'
-import { RealtimeTranslation } from './features/realtime-translation/RealtimeTranslation'
+import { TranslationApp } from './features/realtime-translation/TranslationApp'
 
 const theme = createTheme({
   palette: {
@@ -12,7 +12,7 @@ function App() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <RealtimeTranslation />
+      <TranslationApp />
     </ThemeProvider>
   )
 }

--- a/frontend/src/features/realtime-translation/TextTranslation.tsx
+++ b/frontend/src/features/realtime-translation/TextTranslation.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+import {
+  Box,
+  TextField,
+  Button,
+  Paper,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  CircularProgress,
+} from '@mui/material';
+import { TranslationService } from '../../services/translationService';
+
+const translationService = new TranslationService();
+
+const LANGUAGES = [
+  { code: 'ja', name: '日本語' },
+  { code: 'en', name: '英語' },
+  { code: 'zh', name: '中国語' },
+  { code: 'ko', name: '韓国語' },
+  { code: 'es', name: 'スペイン語' },
+  { code: 'fr', name: 'フランス語' },
+];
+
+export const TextTranslation = () => {
+  const [text, setText] = useState('');
+  const [sourceLanguage, setSourceLanguage] = useState('ja');
+  const [targetLanguage, setTargetLanguage] = useState('en');
+  const [translatedText, setTranslatedText] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleTranslate = async () => {
+    if (!text) return;
+    
+    setIsLoading(true);
+    setError(null);
+    
+    try {
+      const response = await translationService.translateText({
+        text,
+        sourceLanguage,
+        targetLanguage,
+      });
+      setTranslatedText(response.translatedText);
+    } catch (err) {
+      setError('翻訳中にエラーが発生しました。');
+      console.error('Translation error:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Box sx={{ maxWidth: 800, mx: 'auto', mt: 4, p: 2 }}>
+      <Typography variant="h4" component="h1" gutterBottom sx={{ mb: 3 }}>
+        テキスト翻訳
+      </Typography>
+
+      <Box sx={{ display: 'flex', gap: 2, mb: 3 }}>
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel>元の言語</InputLabel>
+          <Select
+            value={sourceLanguage}
+            label="元の言語"
+            onChange={(e) => setSourceLanguage(e.target.value)}
+          >
+            {LANGUAGES.map((lang) => (
+              <MenuItem key={lang.code} value={lang.code}>
+                {lang.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <FormControl sx={{ minWidth: 120 }}>
+          <InputLabel>翻訳先</InputLabel>
+          <Select
+            value={targetLanguage}
+            label="翻訳先"
+            onChange={(e) => setTargetLanguage(e.target.value)}
+          >
+            {LANGUAGES.map((lang) => (
+              <MenuItem key={lang.code} value={lang.code}>
+                {lang.name}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+      </Box>
+
+      {error && (
+        <Typography color="error" sx={{ mb: 2 }}>
+          {error}
+        </Typography>
+      )}
+
+      <Paper elevation={3} sx={{ p: 3, mb: 3 }}>
+        <TextField
+          fullWidth
+          multiline
+          rows={4}
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="翻訳したいテキストを入力してください"
+          variant="outlined"
+        />
+
+        <Box sx={{ display: 'flex', justifyContent: 'flex-end', mt: 2 }}>
+          <Button
+            variant="contained"
+            onClick={handleTranslate}
+            disabled={!text || isLoading}
+          >
+            {isLoading ? (
+              <>
+                <CircularProgress size={20} sx={{ mr: 1 }} />
+                翻訳中...
+              </>
+            ) : (
+              '翻訳'
+            )}
+          </Button>
+        </Box>
+      </Paper>
+
+      {translatedText && (
+        <Paper elevation={3} sx={{ p: 3 }}>
+          <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+            翻訳結果:
+          </Typography>
+          <Typography variant="body1">{translatedText}</Typography>
+        </Paper>
+      )}
+    </Box>
+  );
+};

--- a/frontend/src/features/realtime-translation/TranslationApp.tsx
+++ b/frontend/src/features/realtime-translation/TranslationApp.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { Box, Tabs, Tab } from '@mui/material';
+import { TextTranslation } from './TextTranslation';
+import { RealtimeTranslation } from './RealtimeTranslation';
+
+export const TranslationApp = () => {
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const handleTabChange = (_event: React.SyntheticEvent, newValue: number) => {
+    setCurrentTab(newValue);
+  };
+
+  return (
+    <Box>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider', mb: 2 }}>
+        <Tabs value={currentTab} onChange={handleTabChange} centered>
+          <Tab label="テキスト翻訳" />
+          <Tab label="音声翻訳" />
+        </Tabs>
+      </Box>
+
+      {currentTab === 0 ? <TextTranslation /> : <RealtimeTranslation />}
+    </Box>
+  );
+};


### PR DESCRIPTION
This pull request includes several updates to the frontend of the real-time translation application, including new documentation and feature additions. The most important changes involve the addition of a text translation feature, updates to the setup instructions, and improvements to the overall structure of the frontend application.

### Documentation Updates:
* [`README-ja.md`](diffhunk://#diff-6323ab8bbdb204fef907b113c1c602229d4baef7abcd9c499aba1dd23bfe531cR48-R49): Added a link to the frontend setup instructions.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R48-R49): Added a link to the frontend setup instructions.
* [`frontend/README-ja.md`](diffhunk://#diff-0cc536e75ef6461697bff6c2357ff2bbec2ebf31ed82bcbb4961d146bb50cb0eR1-R109): Added comprehensive setup instructions, feature descriptions, and development details for the frontend application.
* [`frontend/README.md`](diffhunk://#diff-35aa98d245b201cfc92c74313abcf8fa0f6069fc750f05e7a755665360a0e543L1-R63): Updated to include detailed setup instructions, feature descriptions, and development details for the frontend application.

### Feature Additions:
* [`frontend/src/features/realtime-translation/TextTranslation.tsx`](diffhunk://#diff-8e301d7a8dd0cba4a24025c10447b8fa86de5123b0f31611b4d1a78c72198761R1-R139): Added a new component for text translation, including language selection, text input, and translation display.
* [`frontend/src/features/realtime-translation/TranslationApp.tsx`](diffhunk://#diff-828e3654c2252e738d28985ad18b2253f25fd382930fc4e1c68693c5f248cbf7R1-R25): Added a new component to manage tabs for text translation and real-time translation features.

### Codebase Updates:
* [`frontend/src/App.tsx`](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL3-R3): Replaced `RealtimeTranslation` component with `TranslationApp` to integrate the new text translation feature. [[1]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL3-R3) [[2]](diffhunk://#diff-e56cb91573ddb6a97ecd071925fe26504bb5a65f921dc64c63e534162950e1ebL15-R15)