### PR TITLE
fix: correct Japanese README link placement in the introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Real-time translation service using Azure Speech Service.
 
+日本語版のREADMEは[こちら](./README-ja.md)をご覧ください。
+
 ## Generating Go Client Library with AutoRest
 
 We use [AutoRest](https://github.com/Azure/autorest) to generate a client library by loading API specifications. The approach allows generating client libraries in any supported language.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a link to the Japanese version of the README. 

Change details:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5-R6): Added a link to the Japanese version of the README file.